### PR TITLE
[BUGFIX] Set the default value of the datetime field with the current…

### DIFF
--- a/Configuration/TCA/tt_news.php
+++ b/Configuration/TCA/tt_news.php
@@ -212,8 +212,7 @@ return Array (
 				'type' => 'input',
 				'size' => '10',
 				'max' => '20',
-				'eval' => 'datetime',
-				'default' => mktime(date("H"),date("i"),0,date("m"),date("d"),date("Y"))
+				'eval' => 'datetime'
 				)
 		),
 		'archivedate' => Array (

--- a/ext_autoload.php
+++ b/ext_autoload.php
@@ -21,6 +21,7 @@ return array(
 	'tx_ttnews_templateeval' => $extensionPath . 'lib/class.tx_ttnews_templateeval.php',
 	'tx_ttnews_tsparserext' => $extensionPath . 'lib/class.tx_ttnews_tsparserext.php',
 	'tx_ttnews_typo3ajax' => $extensionPath . 'lib/class.tx_ttnews_typo3ajax.php',
+	'tx_ttnews_record_init_new' => $extensionPath . 'lib/class.tx_ttnews_record_init_new.php',
 	'tx_ttnews_wizicon' => $extensionPath . 'pi/class.tx_ttnews_wizicon.php',
 	'tx_ttnewscatmanager_cm1' => $extensionPath . 'cm1/class.tx_ttnewscatmanager_cm1.php',
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -59,4 +59,11 @@ if ($_COOKIE[$configuredCookieName]) {
 }
 
 
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord']['tx_ttnews_record_init_new'] = array(
+	'depends' => array(
+		\TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseRowInitializeNew::class,
+	)
+);
+
+
 

--- a/lib/class.tx_ttnews_record_init_new.php
+++ b/lib/class.tx_ttnews_record_init_new.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+
+
+/**
+ * Fill the news records with default values
+ * taken from the News extension by Georg Ringer
+ */
+class tx_ttnews_record_init_new implements \TYPO3\CMS\Backend\Form\FormDataProviderInterface
+{
+
+    /**
+     * @param array $result
+     * @return array
+     */
+    public function addData(array $result) {
+        if ($result['command'] !== 'new' || $result['tableName'] !== 'tt_news') {
+            return $result;
+        }
+
+        $result['databaseRow']['datetime'] = $GLOBALS['EXEC_TIME'];
+
+        return $result;
+    }
+
+}


### PR DESCRIPTION
… time when creating a new record

The return value of any loaded TCA file will be cached. It's not possible anymore to set the current time in the TCA file.
