### PR TITLE
Fixed plugin.tt_news.pageBrowser.showPBrowserText when disabled.

### DIFF
--- a/lib/class.tx_ttnews_helpers.php
+++ b/lib/class.tx_ttnews_helpers.php
@@ -178,7 +178,7 @@ class tx_ttnews_helpers {
 			$this->pObj->internal['results_at_a_time'] = 1;
 			$this->pObj->internal['maxPages'] = $this->pObj->conf['pageBrowser.']['maxPages'];
 			if (! $this->pObj->conf['pageBrowser.']['showPBrowserText']) {
-				$this->pObj->LOCAL_LANG[$this->pObj->LLkey]['pi_list_browseresults_page'] = '';
+				$this->pObj->LOCAL_LANG[$this->pObj->LLkey]['pi_list_browseresults_page'] = ' ';
 			}
 			$pbConf = $this->pObj->conf['singleViewPageBrowser.'];
 			$markerArray = array();

--- a/pi/class.tx_ttnews.php
+++ b/pi/class.tx_ttnews.php
@@ -779,7 +779,7 @@ class tx_ttnews extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
 					$this->internal['maxPages'] = $pbConf['maxPages'];
 
 					if (! $pbConf['showPBrowserText']) {
-						$this->overrideLL('pi_list_browseresults_page', '');
+						$this->overrideLL('pi_list_browseresults_page', ' ');
 					}
 					if ($this->conf['userPageBrowserFunc']) {
 						$markerArray = $this->userProcess('userPageBrowserFunc', $markerArray);


### PR DESCRIPTION
This is a problem when translation is set to empty string (e.g. using plugin.tt_news.pageBrowser.showPBrowserText = 0). Typo uses default tranlsation, hardcoded in core (AbstractPlugin.php) Typo3 7.6.9.
