### PR TITLE
[FEATURE] #43786 Redirect to [backPid] when there is no translation o…

### DIFF
--- a/pi/class.tx_ttnews.php
+++ b/pi/class.tx_ttnews.php
@@ -1192,6 +1192,12 @@ class tx_ttnews extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
 
 		} elseif ($this->sys_language_mode == 'strict' && $this->tt_news_uid && $this->tsfe->sys_language_content) {
             // not existing translation
+            if($this->conf['redirectNoTranslToList']) {
+                // redirect to list page
+				$this->pi_linkToPage(' ', $this->conf['backPid']);
+                \TYPO3\CMS\Core\Utility\HttpUtility::redirect($this->cObj->lastTypoLinkUrl);
+			}
+
 			$this->upstreamVars['mode'] = 'noTranslation';
 			$noTranslMsg = $this->local_cObj->stdWrap($this->pi_getLL('noTranslMsg'), $this->conf['noNewsIdMsg_stdWrap.']);
 			$content = $noTranslMsg;

--- a/pi/static/ts_new/setup.txt
+++ b/pi/static/ts_new/setup.txt
@@ -591,6 +591,9 @@ plugin.tt_news {
   # don't display empty periods in archive menu
   archiveMenuNoEmpty = 1
 
+  # fallback to new liste page when strict translation mode and no translation is available instead of showing no translation message
+  redirectNoTranslToList = 0
+
   # news with zero datetime will cause the amenu to search all periods starting from 1970. Disabling this is not recommanded.
   ignoreNewsWithoutDatetimeInAmenu = 1
 


### PR DESCRIPTION
…f a news record

Added config variable and handling to redirect in strict translation mode if no translation is available.