### PR TITLE
[BUGFIX] Reset $tempColumns in TCA overrides

### DIFF
--- a/Configuration/TCA/Overrides/be_groups.php
+++ b/Configuration/TCA/Overrides/be_groups.php
@@ -1,6 +1,7 @@
 <?php
 defined('TYPO3_MODE') or die();
 // Load field definition from 'shared' file
+$tempColumns = array();
 $tempColumns['tt_news_categorymounts'] = require TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('tt_news')
                                                  . 'Configuration/TCA/Shared/categorymounts.php';
 TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('be_groups', $tempColumns);

--- a/Configuration/TCA/Overrides/be_users.php
+++ b/Configuration/TCA/Overrides/be_users.php
@@ -1,6 +1,7 @@
 <?php
 defined('TYPO3_MODE') or die();
 // Load field definition from 'shared' file
+$tempColumns = array();
 $tempColumns['tt_news_categorymounts'] = require TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('tt_news')
                                                  . 'Configuration/TCA/Shared/categorymounts.php';
 // show the category selection only in non-admin be_users records


### PR DESCRIPTION
$tempColumns is also being used by TCA definition of the
sr_language_menu extension. When the latter is called before tt_news, it
means $tempColumns is already filled with data relevant to
sr_language_menu only, resulting in many issues.