### PR TITLE
[BUGFIX] Don't use deprecated each()

### DIFF
--- a/pi/class.tx_ttnews.php
+++ b/pi/class.tx_ttnews.php
@@ -1885,7 +1885,7 @@ class tx_ttnews extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
         if (!is_array($lConf)) {
             return;
         } else {
-            while (list($mName) = each($lConf)) {
+            foreach ($lConf as $mName => $val) {
                 $genericMarker = '###GENERIC_' . strtoupper($mName) . '###';
 
                 if (!is_array($lConf[$mName . '.']) || !$this->isRenderMarker($genericMarker)) {

--- a/pi/class.tx_ttnews.php
+++ b/pi/class.tx_ttnews.php
@@ -1547,7 +1547,7 @@ class tx_ttnews extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
 
 		$markerArray = array_flip($this->renderMarkers);
 
-		while (list($mName) = each($markerArray)) {
+		foreach ($markerArray as $mName => $val) {
 			$markerArray[$mName] = '';
 		}
 


### PR DESCRIPTION
each() is deprecated in PHP 7.2 (performance issue) and thus triggers a lot of warnings in the logs. This commit replaces it with foreach().