### PR TITLE
Pagination Results works with Default configuration now

### DIFF
--- a/pi/static/ts_new/setup.txt
+++ b/pi/static/ts_new/setup.txt
@@ -331,7 +331,7 @@ plugin.tt_news {
     showRange = 1
     hscText = 1
 
-    showResultsNumbersWrap = |
+    showResultsNumbersWrap >
     browseBoxWrap = <div class="news-list-browse">|</div>
     showResultsWrap = <div class="showResultsWrap">|</div>
     browseLinksWrap = <div class="browseLinksWrap">|</div>
@@ -355,7 +355,7 @@ plugin.tt_news {
     showRange = 0
     hscText = 1
 
-    showResultsNumbersWrap = |
+    showResultsNumbersWrap >
     browseBoxWrap = <div class="news-single-browse">|</div>
     showResultsWrap = <div class="showResultsWrap">|</div>
     browseLinksWrap = <div class="browseLinksWrap">|</div>


### PR DESCRIPTION
Pagination results were broken because of this configuration. now the pagination results are working fine.
for the root of the Problem and how to use the more flexible way for that results you can check into
typo3/sysext/frontend/Plugins/AbstractPlugin.php:675

![image](https://user-images.githubusercontent.com/1622975/39965685-4ac2213e-56b7-11e8-94ef-c924e9a52818.png)
