### PR TITLE
Fix category filtering not working for non-admin users in Typo3 8.7.x

### DIFF
--- a/Classes/Module/NewsAdminModule.php
+++ b/Classes/Module/NewsAdminModule.php
@@ -983,8 +983,12 @@ class NewsAdminModule extends BaseScriptClass
 
         $savedRoute = false;
         if ($ajax) {
-            $savedRoute = $_GET['route'];
-            $_GET['route'] = '/web/txttnewsM1/';
+            if (version_compare(TYPO3_version, '9.0.0', '>=')) {
+                $savedRoute = $_GET['route'];
+                $_GET['route'] = '/web/txttnewsM1/';
+            } else {
+                $_GET['M'] = '/web/txttnewsM1/';
+            }
         }
         foreach ($allowedCbNames as $n) {
             if ((bool)$show['cb_' . $n]) {


### PR DESCRIPTION
Routing for checkbox "Show only editable records" was wrong. Typo3 8.7.x needs parameter "M" to be set.