### PR TITLE
[BUGFIX] Prevent superfluous newlines in frontend

### DIFF
--- a/Configuration/TypoScript/ts_new/setup.txt
+++ b/Configuration/TypoScript/ts_new/setup.txt
@@ -115,9 +115,7 @@ plugin.tt_news {
       parseFunc.nonTypoTagStdWrap.encapsLines.nonWrappedTag >
     }
 
-    content_stdWrap.parseFunc < lib.parseFunc_RTE
-    content_stdWrap.parseFunc.nonTypoTagStdWrap.encapsLines.addAttributes.P >
-
+    content_stdWrap.parseFunc < lib.parseFunc
 
     # stdWrap for "additional info" (links, files, related news)
     addInfo_stdWrap.wrap = <div class="news-single-additional-info"> | </div>


### PR DESCRIPTION
Use parseFunc instead of parseFunc_RTE.
parseFunc_RTE wraps every line in a `<p>` tag. CKEditor uses `<br />` tags and also adds empty lines for readability of the generated code. This results in lots of unwanted, empty `<p>` paragraphs in the output. Vanilla parseFunc doesn't wrap lines so that solves the problem.

I'm honestly not sure if any other behavior from parseFunc_RTE (which is not in parseFunc) is needed. My understanding is that CKEditor handles that kind of thing by itself before saving content to the database. CKEditor is now the default and only editor in TYPO3 v9.5 but I guess some people might still use something different in v8.7.

To anyone else reading this who has this problem: You can of course easily fix it yourself via your site's Typoscript setup:
```
plugin.tt_news.displaySingle.content_stdWrap.parseFunc < lib.parseFunc
```