### PR TITLE
Add slug for tt_news

### DIFF
--- a/Classes/Plugin/TtNews.php
+++ b/Classes/Plugin/TtNews.php
@@ -4513,7 +4513,7 @@ class TtNews extends AbstractPlugin
      *
      * @return array|string
      */
-    protected function getSingleViewLink(&$singlePid, &$row, $piVarsArray, $urlOnly = false)
+    public function getSingleViewLink(&$singlePid, &$row, $piVarsArray, $urlOnly = false)
     {
         $tmpY = false;
         $tmpM = false;

--- a/Classes/Plugin/TtNews.php
+++ b/Classes/Plugin/TtNews.php
@@ -678,8 +678,11 @@ class TtNews extends AbstractPlugin
         $this->initTemplate();
 
         // Configure caching
-        $this->allowCaching = $this->conf['allowCaching'] ? 1 : 0;
-        if (!$this->allowCaching) {
+        if (isset($this->conf['allowCaching'])) {
+            $this->allowCaching = $this->conf['allowCaching'] ? 1 : 0;
+        }
+
+	    if (!$this->allowCaching) {
             $this->tsfe->set_no_cache();
         }
 

--- a/Classes/Update/PopulateNewsSlugs.php
+++ b/Classes/Update/PopulateNewsSlugs.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace RG\TtNews\Update;
+
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+use TYPO3\CMS\Core\DataHandling\Model\RecordStateFactory;
+use TYPO3\CMS\Core\DataHandling\SlugHelper;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
+use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
+
+/**
+ * Fills tt_news.slug with a proper value
+ */
+class PopulateNewsSlugs implements UpgradeWizardInterface
+{
+    protected $table = 'tt_news';
+
+    protected $fieldName = 'slug';
+
+    /**
+     * @return string Unique identifier of this updater
+     */
+    public function getIdentifier(): string
+    {
+        return 'tt_news_populateslugs';
+    }
+
+    /**
+     * @return string Title of this updater
+     */
+    public function getTitle(): string
+    {
+        return 'Introduce URL parts ("slugs") to all tt_news entries of EXT:tt_news';
+    }
+
+    /**
+     * @return string Longer description of this updater
+     */
+    public function getDescription(): string
+    {
+        return 'Slugs for EXT:tt_news tt_news records';
+    }
+
+    /**
+     * Checks whether updates are required.
+     *
+     * @return bool Whether an update is required (TRUE) or not (FALSE)
+     */
+    public function updateNecessary(): bool
+    {
+        $updateNeeded = false;
+        // Check if the database table even exists
+        if ($this->checkIfWizardIsRequired()) {
+            $updateNeeded = true;
+        }
+        return $updateNeeded;
+    }
+
+    /**
+     * @return string[] All new fields and tables must exist
+     */
+    public function getPrerequisites(): array
+    {
+        return [
+            DatabaseUpdatedPrerequisite::class
+        ];
+    }
+
+    /**
+     * Performs the accordant updates.
+     *
+     * @return bool Whether everything went smoothly or not
+     */
+    public function executeUpdate(): bool
+    {
+        $this->populateSlugs();
+        return true;
+    }
+
+    /**
+     * Fills the database table tt_news with slugs based on the page title and its configuration.
+     */
+    protected function populateSlugs()
+    {
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable($this->table);
+        $queryBuilder = $connection->createQueryBuilder();
+        $queryBuilder->getRestrictions()->removeAll()->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+        $statement = $queryBuilder
+            ->select('*')
+            ->from($this->table)
+            ->where(
+                $queryBuilder->expr()->orX(
+                    $queryBuilder->expr()->eq($this->fieldName, $queryBuilder->createNamedParameter('')),
+                    $queryBuilder->expr()->isNull($this->fieldName)
+                )
+            )
+            // Ensure that live workspace records are handled first
+            ->addOrderBy('t3ver_wsid', 'asc')
+            ->addOrderBy('pid', 'asc')
+            ->execute();
+
+        // Check for existing slugs from realurl
+        $suggestedSlugs = [];
+
+        $fieldConfig = $GLOBALS['TCA'][$this->table]['columns'][$this->fieldName]['config'];
+        $evalInfo = !empty($fieldConfig['eval']) ? GeneralUtility::trimExplode(',', $fieldConfig['eval'], true) : [];
+        $hasToBeUniqueInSite = in_array('uniqueInSite', $evalInfo, true);
+        $hasToBeUniqueInPid = in_array('uniqueInPid', $evalInfo, true);
+        $slugHelper = GeneralUtility::makeInstance(SlugHelper::class, $this->table, $this->fieldName, $fieldConfig);
+
+        while ($record = $statement->fetch()) {
+            $recordId = (int)$record['uid'];
+            $pid = (int)$record['pid'];
+            $languageId = (int)$record['sys_language_uid'];
+            $recordInDefaultLanguage = $languageId > 0 ? (int)$record['l10n_parent'] : $recordId;
+            $slug = $suggestedSlugs[$recordInDefaultLanguage][$languageId] ?? '';
+
+
+            if (empty($slug)) {
+                if ($pid === -1) {
+                    $queryBuilder = $connection->createQueryBuilder();
+                    $queryBuilder->getRestrictions()->removeAll()->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+                    $liveVersion = $queryBuilder
+                        ->select('pid')
+                        ->from($this->table)
+                        ->where(
+                            $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($record['t3ver_oid'], \PDO::PARAM_INT))
+                        )->execute()->fetch();
+                    $pid = (int)$liveVersion['pid'];
+                }
+                $slug = $slugHelper->generate($record, $pid);
+            }
+
+            $state = RecordStateFactory::forName($this->table)
+                ->fromArray($record, $pid, $recordId);
+            if ($hasToBeUniqueInSite && !$slugHelper->isUniqueInSite($slug, $state)) {
+                $slug = $slugHelper->buildSlugForUniqueInSite($slug, $state);
+            }
+            if ($hasToBeUniqueInPid && !$slugHelper->isUniqueInPid($slug, $state)) {
+                $slug = $slugHelper->buildSlugForUniqueInPid($slug, $state);
+            }
+
+            $connection->update(
+                $this->table,
+                [$this->fieldName => $slug],
+                ['uid' => $recordId]
+            );
+        }
+    }
+
+    /**
+     * Check if there are records within database table tt_news with an empty "slug" field.
+     *
+     * @return bool
+     * @throws \InvalidArgumentException
+     */
+    protected function checkIfWizardIsRequired(): bool
+    {
+        $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
+        $queryBuilder = $connectionPool->getQueryBuilderForTable($this->table);
+        $queryBuilder->getRestrictions()->removeAll()->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+
+        $numberOfEntries = $queryBuilder
+            ->count('uid')
+            ->from($this->table)
+            ->where(
+                $queryBuilder->expr()->orX(
+                    $queryBuilder->expr()->eq($this->fieldName, $queryBuilder->createNamedParameter('')),
+                    $queryBuilder->expr()->isNull($this->fieldName)
+                )
+            )
+            ->execute()
+            ->fetchColumn();
+        return $numberOfEntries > 0;
+    }
+}

--- a/Configuration/TCA/tt_news.php
+++ b/Configuration/TCA/tt_news.php
@@ -398,6 +398,26 @@ return [
                 'minitems' => '0'
             ]
         ],
+        'slug' =>  [
+                'exclude' => true,
+                'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_tca.xlf:pages.slug',
+                'displayCond' => 'USER:' . \TYPO3\CMS\Core\Compatibility\PseudoSiteTcaDisplayCondition::class . '->isInPseudoSite:pages:false',
+                'config' => [
+                    'type' => 'slug',
+                    'size' => 50,
+                    'generatorOptions' => [
+                        'fields' => ['title'],
+                        'fieldSeparator' => '-',
+                        'replacements' => [
+                            '/' => '',
+                            '®' => 'R',
+                        ],
+                    ],
+                    'fallbackCharacter' => '-',
+                    'eval' => 'uniqueInSite',
+                    'default' => ''
+                ]
+        ],
         'sys_language_uid' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.language',

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -4,7 +4,7 @@ $EM_CONF['tt_news'] = [
     'title' => 'News',
     'description' => 'Website news with front page teasers and article handling inside.',
     'category' => 'plugin',
-    'version' => '9.5.3',
+    'version' => '9.5.4',
     'module' => 'mod1',
     'state' => 'beta',
     'uploadfolder' => 1,
@@ -16,7 +16,7 @@ $EM_CONF['tt_news'] = [
     'author_company' => 'www.pick2.de',
     'constraints' => [
         'depends' => [
-            'typo3' => '8.7.0-9.5.99',
+            'typo3' => '9.5.0-9.5.99',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -76,6 +76,6 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRe
 );
 
 if (version_compare(TYPO3_branch, '9.5', '>=')) {
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['txMyExtExampeSlugs']
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['tt_news_populateslugs']
         = \RG\TtNews\Update\PopulateNewsSlugs::class;
 }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -74,3 +74,8 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRe
 		\TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseRowInitializeNew::class,
 	)
 );
+
+if (version_compare(TYPO3_branch, '9.5', '>=')) {
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['txMyExtExampeSlugs']
+        = \RG\TtNews\Update\PopulateNewsSlugs::class;
+}

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -34,6 +34,8 @@ CREATE TABLE tt_news (
   archivedate int(11) DEFAULT '0' NOT NULL,
   ext_url varchar(255) DEFAULT '' NOT NULL,
   
+  slug varchar(2048),
+  
   sys_language_uid int(11) DEFAULT '0' NOT NULL,
   l18n_parent int(11) DEFAULT '0' NOT NULL,
   l18n_diffsource mediumblob NOT NULL,


### PR DESCRIPTION
To keep the same URL part as before update it is necessary to add a slug.
This sould fix #118 .

```routeEnhancers:
  TtNewsDetail:
    type: Plugin
    namespace: 'tx_ttnews'
    routePath: '/view/{tt_news}'
    aspects:
      tt_news:
        type: PersistedAliasMapper
        tableName: tt_news
        routeFieldName: slug
    defaults:
      tt_news: '0'
    requirements:
      tt_news: '[0-9]{1..8}'
```