### PR TITLE
Add extension-key to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,5 +30,10 @@
     "psr-4": {
       "RG\\TtNews\\": "Classes/"
     }
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "tt_news"
+    }
   }
 }


### PR DESCRIPTION
Since version 3.1.0 of `typo3/cms-composer-installers` the `extension-key` is required in `composer.json`:
https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra