### PR TITLE
[BUGFIX] Set proper size of flexform categorySelection

### DIFF
--- a/Resources/Private/Flexform/flexform_ds.xml
+++ b/Resources/Private/Flexform/flexform_ds.xml
@@ -246,8 +246,7 @@
                                     </appearance>
                                 </treeConfig>
                                 <foreign_table_where>ORDER BY tt_news_cat.title</foreign_table_where>
-                                <size>5</size>
-                                <autoSizeMax>40</autoSizeMax>
+                                <size>10</size>
                                 <minitems>0</minitems>
                                 <maxitems>99</maxitems>
 


### PR DESCRIPTION
The option `[config][autoSizeMax]` have no influence on the rendering of FormEngine select field configured with `'renderType' => 'selectTree'` anymore.
The option `autosizemax` has been dropped as the `size` can be used as maximum height.
https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/8.3/Breaking-77081-RemovedTCASelectTreeOptions.html