### PR TITLE
[TASK] Remove TCA configuration showRecordFieldList

### DIFF
--- a/Configuration/TCA/tt_news.php
+++ b/Configuration/TCA/tt_news.php
@@ -61,9 +61,6 @@ return [
         'iconfile' => 'EXT:tt_news/Resources/Public/Images/Icons/ext_icon.gif',
         'searchFields' => 'uid,title,short,bodytext'
     ],
-    'interface' => [
-        'showRecordFieldList' => 'title,hidden,datetime,starttime,archivedate,category,author,author_email,short,image,imagecaption,links,related,news_files'
-    ],
     'columns' => [
         'starttime' => [
             'exclude' => 1,

--- a/Configuration/TCA/tt_news_cat.php
+++ b/Configuration/TCA/tt_news_cat.php
@@ -25,9 +25,6 @@ return [
         'iconfile' => 'EXT:tt_news/Resources/Public/Images/Icons/tt_news_cat.gif',
         'searchFields' => 'uid,title'
     ],
-    'interface' => [
-        'showRecordFieldList' => 'title,image,shortcut,shortcut_target'
-    ],
     'columns' => [
         'title' => [
             'label' => $locallang_general . 'LGL.title',


### PR DESCRIPTION
The TCA configuration `showRecordFieldList` inside the section `interface` is not evaluated anymore and all occurrences have been removed.
https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.3/Feature-88901-RenderAllFieldsInElementInformationController.html#impact