### PR TITLE
[REGRESSION] no category is treated es forbidden by DataHandlerHook

### DIFF
--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -159,6 +159,10 @@ class DataHandlerHook
             $allowedItems = $allowedItems ? GeneralUtility::intExplode(',', $allowedItems) : Div::getAllowedTreeIDs();
 
             $wantedCategories = GeneralUtility::intExplode(',', $fieldArray['category']);
+
+            // allow no categories at all (as wantedCategories will bei [0] if fieldArray['category'] is empty)
+            $allowedItems[] = 0;
+
             foreach ($wantedCategories as $wantedCategory) {
                 $categories[$wantedCategory] = $wantedCategory;
             }


### PR DESCRIPTION
The new handling of allowed categories introduced via 4e39524782366d8cedaff4978737f0192bb395c4 and released with v11.0.0 expects the category field to always be filled.

If no category is set (which was valid in all versions before) the converter for `wantedCategories` interprets the empty field `category`as 0.

This patch re-allows empty category.

In order to keep the clear structure of the function, instead of handling empty category before the conversion, it just adds `0` as allowed, on top of all other allowed categories.