### PR TITLE
[FEATURE] PHP8.1 compatibility

### DIFF
--- a/Classes/Plugin/TtNews.php
+++ b/Classes/Plugin/TtNews.php
@@ -2835,7 +2835,7 @@ class TtNews extends AbstractPlugin
                 $m = '';
             }
             $markerArray['###' . $marker . $m . '###'] = $this->local_cObj->stdWrap($markerArray['###' . $marker . $m . '###'],
-                $lConf['image.']['noImage_stdWrap.']);
+                $lConf['image.']['noImage_stdWrap.'] ?? []);
         }
 
         return $markerArray;

--- a/Classes/Plugin/TtNews.php
+++ b/Classes/Plugin/TtNews.php
@@ -753,12 +753,12 @@ class TtNews extends AbstractPlugin
                 $searchMarkers = array(
                     '###FORM_URL###' => $this->pi_linkTP_keepPIvars_url(array('pointer' => null, 'cat' => null), 0, 1,
                         $this->config['searchPid']),
-                    '###SWORDS###' => htmlspecialchars($this->piVars['swords']),
+                    '###SWORDS###' => htmlspecialchars($this->piVars['swords'] ?? ''),
                     '###SEARCH_BUTTON###' => $this->pi_getLL('searchButtonLabel')
                 );
 
                 // Hook for any additional form fields
-                if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['tt_news']['additionalFormSearchFields'])) {
+                if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['tt_news']['additionalFormSearchFields'] ?? null)) {
                     foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['tt_news']['additionalFormSearchFields'] as $_classRef) {
                         $_procObj = GeneralUtility::makeInstance($_classRef);
                         $searchMarkers = $_procObj->additionalFormSearchFields($this, $searchMarkers);
@@ -775,7 +775,7 @@ class TtNews extends AbstractPlugin
                 unset($searchSub);
 
                 // do the search and add the result to the $where string
-                if ($this->piVars['swords']) {
+                if (isset($this->piVars['swords'])) {
                     $where = $this->searchWhere(trim($this->piVars['swords']));
                     $theCode = 'SEARCH';
                 } else {
@@ -788,7 +788,7 @@ class TtNews extends AbstractPlugin
                 $prefix_display = 'displayXML';
                 // $this->arcExclusive = -1; // Only latest, non archive news
                 $this->allowCaching = $this->conf['displayXML.']['xmlCaching'];
-                $this->config['limit'] = $this->conf['displayXML.']['xmlLimit'] ? $this->conf['displayXML.']['xmlLimit'] : $this->config['limit'];
+                $this->config['limit'] = $this->conf['displayXML.']['xmlLimit'] ?? $this->config['limit'] ?? null;
 
                 switch ($this->conf['displayXML.']['xmlFormat']) {
                     case 'rss091' :
@@ -3684,7 +3684,7 @@ class TtNews extends AbstractPlugin
 
                     $pL = intval($this->piVars['pL']);
                     //selecting news for a certain day only
-                    if (intval($this->piVars['day'])) {
+                    if (intval($this->piVars['day'] ?? 0)) {
                         // = 24h, as pS always starts at the beginning of a day (00:00:00)
                         $pL = 86400;
                     }
@@ -4248,7 +4248,7 @@ class TtNews extends AbstractPlugin
         // pid_list is the pid/list of pids from where to fetch the news items.
         $pid_list = $this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'pages', 's_misc');
         $pid_list = $pid_list ? $pid_list : trim($this->cObj->stdWrap($this->conf['pid_list'],
-            $this->conf['pid_list.']));
+            $this->conf['pid_list.'] ?? []));
         $pid_list = $pid_list ? implode(',', GeneralUtility::intExplode(',', $pid_list)) : $this->tsfe->id;
 
         $recursive = $this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'recursive', 's_misc');

--- a/Classes/Plugin/TtNews.php
+++ b/Classes/Plugin/TtNews.php
@@ -3367,9 +3367,9 @@ class TtNews extends AbstractPlugin
         $tmpPS = false;
         $tmpPL = false;
         if ($this->conf['useHRDates']) {
-            $tmpPS = $this->piVars['pS'];
+            $tmpPS = $this->piVars['pS'] ?? null;
             unset($this->piVars['pS']);
-            $tmpPL = $this->piVars['pL'];
+            $tmpPL = $this->piVars['pL'] ?? null;
             unset($this->piVars['pL']);
         }
 

--- a/Classes/Plugin/TtNews.php
+++ b/Classes/Plugin/TtNews.php
@@ -477,7 +477,7 @@ class TtNews extends AbstractPlugin
         // Init FlexForm configuration for plugin
         $this->pi_initPIflexForm();
 
-        $flexformTyposcript = $this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'myTS', 's_misc');
+        $flexformTyposcript = $this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null, 'myTS', 's_misc');
         if ($flexformTyposcript) {
             /** @var TypoScriptParser $tsparser */
             $tsparser = GeneralUtility::makeInstance(TypoScriptParser::class);
@@ -490,7 +490,7 @@ class TtNews extends AbstractPlugin
         }
 
         // "CODE" decides what is rendered: codes can be set by TS or FF with priority on FF
-        $code = $this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'what_to_display', 'sDEF');
+        $code = $this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null, 'what_to_display', 'sDEF');
         $this->config['code'] = ($code ? $code : $this->cObj->stdWrap($this->conf['code'], $this->conf['code.'] ?? []));
 
         if (($this->conf['displayCurrentRecord'] ?? false)) {
@@ -566,7 +566,7 @@ class TtNews extends AbstractPlugin
         $this->config['archiveMode'] = $archiveMode ? $archiveMode : 'month';
 
         // arcExclusive : -1=only non-archived; 0=don't care; 1=only archived
-        $arcExclusive = $this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'archive', 'sDEF');
+        $arcExclusive = $this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null, 'archive', 'sDEF');
         $this->arcExclusive = $arcExclusive ? $arcExclusive : intval($this->conf['archive']);
 
         $this->config['datetimeDaysToArchive'] = intval($this->conf['datetimeDaysToArchive'] ?? 0);
@@ -592,28 +592,28 @@ class TtNews extends AbstractPlugin
 
         $this->config['singleViewPointerName'] = trim($this->conf['singleViewPointerName'] ?? '') ?: 'sViewPointer';
 
-        $maxWordsInSingleView = intval($this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'maxWordsInSingleView',
+        $maxWordsInSingleView = intval($this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null, 'maxWordsInSingleView',
             's_misc'));
         $maxWordsInSingleView = $maxWordsInSingleView ?: intval($this->conf['maxWordsInSingleView']);
         $this->config['maxWordsInSingleView'] = $maxWordsInSingleView ?: 0;
         $this->config['useMultiPageSingleView'] = $this->conf['useMultiPageSingleView'];
 
         // pid of the page with the single view. the old var PIDitemDisplay is still processed if no other value is found
-        $singlePid = $this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'PIDitemDisplay', 's_misc');
+        $singlePid = $this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null, 'PIDitemDisplay', 's_misc');
         $this->config['singlePid'] = $singlePid ?: intval($this->cObj->stdWrap(($this->conf['singlePid'] ?? 0),
             ($this->conf['singlePid.'] ?? false)));
         if (!$this->config['singlePid']) {
             $this->errors[] = 'No singlePid defined';
         }
         // pid to return to when leaving single view
-        $backPid = intval($this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'backPid', 's_misc'));
+        $backPid = intval($this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null, 'backPid', 's_misc'));
         $backPid = $backPid ?: intval($this->conf['backPid'] ?? 0);
         $backPid = $backPid ?: intval($this->piVars['backPid'] ?? 0);
         $backPid = $backPid ?: $this->tsfe->id;
         $this->config['backPid'] = $backPid;
 
         // max items per page
-        $FFlimit = MathUtility::forceIntegerInRange($this->pi_getFFvalue($this->cObj->data['pi_flexform'],
+        $FFlimit = MathUtility::forceIntegerInRange($this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null,
             'listLimit', 's_template'), 0, 1000);
 
         $limit = MathUtility::forceIntegerInRange($this->cObj->stdWrap(($this->conf['limit'] ?? 0),
@@ -627,13 +627,13 @@ class TtNews extends AbstractPlugin
         $this->config['latestLimit'] = $FFlimit ? $FFlimit : $latestLimit;
 
         // orderBy and groupBy statements for the list Query
-        $orderBy = $this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'listOrderBy', 'sDEF');
+        $orderBy = $this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null, 'listOrderBy', 'sDEF');
         $orderByTS = trim($this->conf['listOrderBy'] ?? '');
         $orderBy = $orderBy ? $orderBy : $orderByTS;
         $this->config['orderBy'] = $orderBy;
 
         if ($orderBy) {
-            $ascDesc = $this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'ascDesc', 'sDEF');
+            $ascDesc = $this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null, 'ascDesc', 'sDEF');
             $this->config['ascDesc'] = $ascDesc;
             if ($this->config['ascDesc']) {
                 // remove ASC/DESC from 'orderBy' if it is already set from TS
@@ -643,9 +643,9 @@ class TtNews extends AbstractPlugin
         $this->config['groupBy'] = trim($this->conf['listGroupBy'] ?? '');
 
         // if this is set, the first image is handled as preview image, which is only shown in list view
-        $fImgPreview = $this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'firstImageIsPreview', 's_misc');
+        $fImgPreview = $this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null, 'firstImageIsPreview', 's_misc');
         $this->config['firstImageIsPreview'] = $fImgPreview ?: ($this->conf['firstImageIsPreview'] ?? false);
-        $forcefImgPreview = $this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'forceFirstImageIsPreview',
+        $forcefImgPreview = $this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null, 'forceFirstImageIsPreview',
             's_misc');
         $this->config['forceFirstImageIsPreview'] = $forcefImgPreview ? $fImgPreview : ($this->conf['forceFirstImageIsPreview'] ?? false);
 
@@ -653,32 +653,32 @@ class TtNews extends AbstractPlugin
         //		$listStartId = intval($this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'listStartId', 's_misc'));
         //		$this->config['listStartId'] = /*$listStartId?$listStartId:*/intval($this->conf['listStartId']);
         // supress pagebrowser
-        $noPageBrowser = $this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'noPageBrowser', 's_template');
+        $noPageBrowser = $this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null, 'noPageBrowser', 's_template');
         $this->config['noPageBrowser'] = $noPageBrowser ?: ($this->conf['noPageBrowser'] ?? false);
 
         // image sizes/optionSplit given from FlexForms
-        $this->config['FFimgH'] = trim($this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'imageMaxHeight',
+        $this->config['FFimgH'] = trim($this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null, 'imageMaxHeight',
             's_template'));
-        $this->config['FFimgW'] = trim($this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'imageMaxWidth',
+        $this->config['FFimgW'] = trim($this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null, 'imageMaxWidth',
             's_template'));
 
         // Get number of alternative Layouts (loop layout in LATEST and LIST view) default is 2:
-        $altLayouts = intval($this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'alternatingLayouts',
+        $altLayouts = intval($this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null, 'alternatingLayouts',
             's_template'));
         $altLayouts = $altLayouts ?: intval($this->conf['alternatingLayouts'] ?? 0);
         $this->alternatingLayouts = $altLayouts ?: 2;
 
-        $altLayouts = trim($this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'altLayoutsOptionSplit',
+        $altLayouts = trim($this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null, 'altLayoutsOptionSplit',
             's_template'));
         $this->config['altLayoutsOptionSplit'] = $altLayouts ?: trim($this->conf['altLayoutsOptionSplit'] ?? '');
 
         // Get cropping length
 
 
-        $croppingLenghtOptionSplit = trim($this->pi_getFFvalue($this->cObj->data['pi_flexform'],
+        $croppingLenghtOptionSplit = trim($this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null,
             'croppingLenghtOptionSplit', 's_template'));
         $this->config['croppingLenghtOptionSplit'] = $croppingLenghtOptionSplit ?: trim($this->conf['croppingLenghtOptionSplit'] ?? '');
-        $this->config['croppingLenght'] = trim($this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'croppingLenght',
+        $this->config['croppingLenght'] = trim($this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null, 'croppingLenght',
             's_template'));
 
         $this->initTemplate();
@@ -787,7 +787,7 @@ class TtNews extends AbstractPlugin
             case 'XML' :
                 $prefix_display = 'displayXML';
                 // $this->arcExclusive = -1; // Only latest, non archive news
-                $this->allowCaching = $this->conf['displayXML.']['xmlCaching'];
+                $this->allowCaching = $this->conf['displayXML.']['xmlCaching'] ?? null;
                 $this->config['limit'] = $this->conf['displayXML.']['xmlLimit'] ?? $this->config['limit'] ?? null;
 
                 switch ($this->conf['displayXML.']['xmlFormat']) {
@@ -906,7 +906,7 @@ class TtNews extends AbstractPlugin
             }
 
             // exclude the LATEST template from changing its content with the pagebrowser. This can be overridden by setting the conf var latestWithPagebrowser
-            if ($this->theCode != 'LATEST' || $this->conf['latestWithPagebrowser']) {
+            if ($this->theCode != 'LATEST' || ($this->conf['latestWithPagebrowser'] ?? null)) {
                 $selectConf['begin'] = intval($this->piVars[$this->pointerName] ?? 0) * $this->config['limit'];
             }
 
@@ -979,8 +979,8 @@ class TtNews extends AbstractPlugin
                         $markerArray = $this->getPagebrowserContent($markerArray, $pbConf, $this->pointerName);
 
                     } else {
-                        $markerArray['###BROWSE_LINKS###'] = $this->makePageBrowser($pbConf['showResultCount'],
-                            $pbConf['tableParams'], $this->pointerName);
+                        $markerArray['###BROWSE_LINKS###'] = $this->makePageBrowser($pbConf['showResultCount'] ?? 1,
+                            $pbConf['tableParams'] ?? '', $this->pointerName);
                     }
                 }
             }
@@ -1005,7 +1005,7 @@ class TtNews extends AbstractPlugin
                 $this->spMarker('###TEMPLATE_SEARCH_EMPTY###'));
 
             $content .= $this->markerBasedTemplateService->substituteMarkerArrayCached($searchEmptyMsg, $markerArray);
-        } elseif ($this->piVars['swords']) {
+        } elseif ($this->piVars['swords'] ?? null) {
             // no results
             $markerArray['###SEARCH_EMPTY_MSG###'] = $this->local_cObj->stdWrap($this->pi_getLL('noResultsMsg'),
                 $this->conf['searchEmptyMsg_stdWrap.']);
@@ -1037,7 +1037,7 @@ class TtNews extends AbstractPlugin
             $t['total'] = $this->markerBasedTemplateService->substituteSubpart($t['total'], '###CONTENT###', '', 0);
 
             $content .= $t['total'];
-        } elseif ($this->arcExclusive && $this->piVars['pS'] && $this->sys_language_content) {
+        } elseif ($this->arcExclusive && ($this->piVars['pS'] ?? null) && $this->sys_language_content) {
             $markerArray = array();
             // this matches if a user has switched languages within a archive period that contains no items in the desired language
             $content .= $this->local_cObj->stdWrap($this->pi_getLL('noNewsForArchPeriod'),
@@ -1208,7 +1208,7 @@ class TtNews extends AbstractPlugin
             }
 
             $wrappedSubpartArray = array();
-            $titleField = $lConf['linkTitleField'] ? $lConf['linkTitleField'] : '';
+            $titleField = $lConf['linkTitleField'] ?? '';
 
             // First get workspace/version overlay:
             if ($this->versioningEnabled) {
@@ -1224,8 +1224,8 @@ class TtNews extends AbstractPlugin
             // Register displayed news item globally:
             $GLOBALS['T3_VAR']['displayedNews'][] = $row['uid'];
 
-            $this->tsfe->ATagParams = $pTmp . ' title="' . $this->local_cObj->stdWrap(trim(htmlspecialchars($row[$titleField])),
-                    $lConf['linkTitleField.']) . '"';
+            $this->tsfe->ATagParams = $pTmp . ' title="' . $this->local_cObj->stdWrap(trim(htmlspecialchars($row[$titleField] ?? '')),
+                    $lConf['linkTitleField.'] ?? []) . '"';
 
             if ($this->conf[$prefix_display . '.']['catOrderBy'] ?? false) {
                 $this->config['catOrderBy'] = $this->conf[$prefix_display . '.']['catOrderBy'];
@@ -1929,7 +1929,7 @@ class TtNews extends AbstractPlugin
         }
         if ($row['author'] && $this->isRenderMarker('###NEWS_AUTHOR###')) {
             $newsAuthor = $this->local_cObj->stdWrap($row['author'] ? $this->local_cObj->stdWrap($this->pi_getLL('preAuthor'),
-                    $lConf['preAuthor_stdWrap.']) . $row['author'] : '', $lConf['author_stdWrap.']);
+                    $lConf['preAuthor_stdWrap.'] ?? []) . $row['author'] : '', $lConf['author_stdWrap.'] ?? []);
             $markerArray['###NEWS_AUTHOR###'] = $this->formatStr($newsAuthor);
         }
         if ($row['author_email'] && $this->isRenderMarker('###NEWS_EMAIL###')) {
@@ -1939,17 +1939,17 @@ class TtNews extends AbstractPlugin
 
         if ($row['datetime']) {
             if ($this->isRenderMarker('###NEWS_DATE###')) {
-                $markerArray['###NEWS_DATE###'] = $this->local_cObj->stdWrap($row['datetime'], $lConf['date_stdWrap.']);
+                $markerArray['###NEWS_DATE###'] = $this->local_cObj->stdWrap($row['datetime'], $lConf['date_stdWrap.'] ?? []);
             }
             if ($this->isRenderMarker('###NEWS_TIME###')) {
-                $markerArray['###NEWS_TIME###'] = $this->local_cObj->stdWrap($row['datetime'], $lConf['time_stdWrap.']);
+                $markerArray['###NEWS_TIME###'] = $this->local_cObj->stdWrap($row['datetime'], $lConf['time_stdWrap.'] ?? []);
             }
             if ($this->isRenderMarker('###NEWS_AGE###')) {
-                $markerArray['###NEWS_AGE###'] = $this->local_cObj->stdWrap($row['datetime'], $lConf['age_stdWrap.']);
+                $markerArray['###NEWS_AGE###'] = $this->local_cObj->stdWrap($row['datetime'], $lConf['age_stdWrap.'] ?? []);
             }
             if ($this->isRenderMarker('###TEXT_NEWS_AGE###')) {
                 $markerArray['###TEXT_NEWS_AGE###'] = $this->local_cObj->stdWrap($this->pi_getLL('textNewsAge'),
-                    $lConf['textNewsAge_stdWrap.']);
+                    $lConf['textNewsAge_stdWrap.'] ?? []);
             }
         }
 
@@ -3374,7 +3374,7 @@ class TtNews extends AbstractPlugin
         }
 
         // Initializing variables:
-        $pointer = $this->piVars[$pointerName];
+        $pointer = $this->piVars[$pointerName] ?? 0;
         $count = $this->internal['res_count'];
         $results_at_a_time = MathUtility::forceIntegerInRange($this->internal['results_at_a_time'],
             1, 1000);
@@ -4067,7 +4067,7 @@ class TtNews extends AbstractPlugin
 
         $addWhere = $this->SPaddWhere . $this->enableCatFields;
 
-        $useSubCategories = $this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'useSubCategories', 'sDEF');
+        $useSubCategories = $this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null, 'useSubCategories', 'sDEF');
         $this->config['useSubCategories'] = (strcmp($useSubCategories,
             '') ? $useSubCategories : $this->conf['useSubCategories']);
 
@@ -4076,7 +4076,7 @@ class TtNews extends AbstractPlugin
         $this->config['catOrderBy'] = $catOrderBy ? $catOrderBy : 'sorting';
 
         // categoryModes are: 0=display all categories, 1=display selected categories, -1=display deselected categories
-        $categoryMode = $this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'categoryMode', 'sDEF');
+        $categoryMode = $this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null, 'categoryMode', 'sDEF');
 
         $this->config['categoryMode'] = $categoryMode ? $categoryMode : intval($this->conf['categoryMode']);
         // catselection holds only the uids of the categories selected by GETvars
@@ -4093,7 +4093,7 @@ class TtNews extends AbstractPlugin
                     array_unique(explode(',', $this->config['catSelection'] . ($subcats ? ',' . $subcats : ''))));
             }
         }
-        $catExclusive = $this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'categorySelection', 'sDEF');
+        $catExclusive = $this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null, 'categorySelection', 'sDEF');
         $catExclusive = $catExclusive ? $catExclusive : trim($this->cObj->stdWrap($this->conf['categorySelection'],
             $this->conf['categorySelection.'] ?? false));
         // ignore cat selection if categoryMode isn't set
@@ -4115,7 +4115,7 @@ class TtNews extends AbstractPlugin
         $fields = explode(',',
             'catImageMode,catTextMode,catImageMaxWidth,catImageMaxHeight,maxCatImages,catTextLength,maxCatTexts');
         foreach ($fields as $key) {
-            $value = $this->pi_getFFvalue($this->cObj->data['pi_flexform'], $key, 's_category');
+            $value = $this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null, $key, 's_category');
             $this->config[$key] = (is_numeric($value) ? $value : ($this->conf[$key] ?? 0));
         }
     }
@@ -4207,7 +4207,7 @@ class TtNews extends AbstractPlugin
     protected function initTemplate()
     {
         // read template-file and fill and substitute the Global Markers
-        $templateflex_file = $this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'template_file', 's_template');
+        $templateflex_file = $this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null, 'template_file', 's_template');
         if ($templateflex_file) {
             if (false === strpos($templateflex_file, '/')) {
                 $templateflex_file = 'uploads/tx_ttnews/' . $templateflex_file;
@@ -4246,12 +4246,12 @@ class TtNews extends AbstractPlugin
     public function initPidList()
     {
         // pid_list is the pid/list of pids from where to fetch the news items.
-        $pid_list = $this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'pages', 's_misc');
+        $pid_list = $this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null, 'pages', 's_misc');
         $pid_list = $pid_list ? $pid_list : trim($this->cObj->stdWrap($this->conf['pid_list'],
             $this->conf['pid_list.'] ?? []));
         $pid_list = $pid_list ? implode(',', GeneralUtility::intExplode(',', $pid_list)) : $this->tsfe->id;
 
-        $recursive = $this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'recursive', 's_misc');
+        $recursive = $this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null, 'recursive', 's_misc');
         if (!strcmp($recursive, '') || $recursive === null) {
             $recursive = $this->cObj->stdWrap($this->conf['recursive'], $this->conf['recursive.'] ?? []);
         }

--- a/Classes/Plugin/TtNews.php
+++ b/Classes/Plugin/TtNews.php
@@ -2941,7 +2941,7 @@ class TtNews extends AbstractPlugin
                         'parent_category' => (!GeneralUtility::inList($maincat,
                             $val['uid']) && $this->conf['displaySubCategories'] ? $val['parent_category'] : ''),
                         'sorting' => $val['sorting'],
-                        'mmsorting' => $val['mmsorting']
+                        'mmsorting' => $val['mmsorting'] ?? null
                     );
 
                 }

--- a/Classes/Plugin/TtNews.php
+++ b/Classes/Plugin/TtNews.php
@@ -2439,9 +2439,9 @@ class TtNews extends AbstractPlugin
         if (count($this->categories[$row['uid']]) && ($this->config['catImageMode'] || $this->config['catTextMode'])) {
             // wrap for all categories
             $cat_stdWrap = GeneralUtility::trimExplode('|',
-                $lConf['category_stdWrap.']['wrap']);
-            $markerArray['###CATWRAP_B###'] = $cat_stdWrap[0];
-            $markerArray['###CATWRAP_E###'] = $cat_stdWrap[1];
+                $lConf['category_stdWrap.']['wrap'] ?? '');
+            $markerArray['###CATWRAP_B###'] = $cat_stdWrap[0] ?? '';
+            $markerArray['###CATWRAP_E###'] = $cat_stdWrap[1] ?? '';
             $markerArray['###TEXT_CAT###'] = $this->pi_getLL('textCat');
             $markerArray['###TEXT_CAT_LATEST###'] = $this->pi_getLL('textCatLatest');
 
@@ -2555,7 +2555,7 @@ class TtNews extends AbstractPlugin
                     // add linked category image to output array
                     $img = $this->local_cObj->cObjGetSingle('IMAGE', $catPicConf['image.']);
                     $swrap = ($val['parent_category'] > 0 ? 'subCategoryImgItem_stdWrap.' : 'categoryImgItem_stdWrap.');
-                    $theCatImgCodeArray[] = $this->local_cObj->stdWrap($img, $lConf[$swrap]);
+                    $theCatImgCodeArray[] = $this->local_cObj->stdWrap($img, $lConf[$swrap] ?? []);
                 }
                 if (!$wroteRegister) {
                     // Load the uid of the first assigned category to the register 'newsCategoryUid'
@@ -2590,7 +2590,7 @@ class TtNews extends AbstractPlugin
                 $xmlCategories = '';
                 foreach ($newsCategories as $xmlCategory) {
                     $xmlCategories .= '<category>' . $this->local_cObj->stdWrap($xmlCategory,
-                            $lConf['categoryTitles_stdWrap.']) . '</category>' . "\n\t\t\t";
+                            $lConf['categoryTitles_stdWrap.'] ?? []) . '</category>' . "\n\t\t\t";
                 }
 
                 $markerArray['###NEWS_CATEGORY###'] = $xmlCategories;

--- a/Classes/Plugin/TtNews.php
+++ b/Classes/Plugin/TtNews.php
@@ -979,7 +979,7 @@ class TtNews extends AbstractPlugin
                         $markerArray = $this->getPagebrowserContent($markerArray, $pbConf, $this->pointerName);
 
                     } else {
-                        $markerArray['###BROWSE_LINKS###'] = $this->makePageBrowser($pbConf['showResultCount'] ?? 1,
+                        $markerArray['###BROWSE_LINKS###'] = $this->makePageBrowser($pbConf['showResultCount'] ?? null,
                             $pbConf['tableParams'] ?? '', $this->pointerName);
                     }
                 }

--- a/Classes/Plugin/TtNews.php
+++ b/Classes/Plugin/TtNews.php
@@ -1112,6 +1112,13 @@ class TtNews extends AbstractPlugin
             $this->pi_lowerThan = $highestVal + 1;
         }
 
+
+        // hotfix AbstractPlugin not php8.1 compatible
+        // https://review.typo3.org/c/Packages/TYPO3.CMS/+/76642
+        if (!isset($this->piVars[$pointerName])) {
+            $this->piVars[$pointerName] = 0;
+        }
+        // end hotfix
         // render pagebrowser
         $markerArray['###BROWSE_LINKS###'] = $this->pi_list_browseresults($pbConf['showResultCount'],
             $pbConf['tableParams'] ?? null, $wrapArr, $pointerName, $pbConf['hscText']);
@@ -2080,7 +2087,7 @@ class TtNews extends AbstractPlugin
         //		debug($markerArray, ' ('.__CLASS__.'::'.__FUNCTION__.')', __LINE__, __FILE__, 3);
 
         // Adds hook for processing of extra item markers
-        if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['tt_news']['extraItemMarkerHook'])) {
+        if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['tt_news']['extraItemMarkerHook'] ?? null)) {
             foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['tt_news']['extraItemMarkerHook'] as $_classRef) {
                 $_procObj = GeneralUtility::makeInstance($_classRef);
                 $markerArray = $_procObj->extraItemMarkerProcessor($markerArray, $row, $lConf, $this);
@@ -4557,6 +4564,7 @@ class TtNews extends AbstractPlugin
         $piVarsArray['tt_news'] = $row['uid'];
 
         // hotfix AbstractPlugin not php8.1 compatible
+        // https://review.typo3.org/c/Packages/TYPO3.CMS/+/76598
         if (!isset($this->conf['parent.']['addParams'])) {
             $this->conf['parent.']['addParams'] = '';
         }

--- a/Classes/Plugin/TtNews.php
+++ b/Classes/Plugin/TtNews.php
@@ -494,7 +494,7 @@ class TtNews extends AbstractPlugin
         $this->config['code'] = ($code ? $code : $this->cObj->stdWrap($this->conf['code'], $this->conf['code.'] ?? []));
 
         if (($this->conf['displayCurrentRecord'] ?? false)) {
-            $this->config['code'] = $this->conf['defaultCode'] ? trim($this->conf['defaultCode']) : 'SINGLE';
+            $this->config['code'] = ($this->conf['defaultCode'] ?? null) ? trim($this->conf['defaultCode']) : 'SINGLE';
             $this->tt_news_uid = $this->cObj->data['uid'];
         }
 
@@ -567,7 +567,7 @@ class TtNews extends AbstractPlugin
 
         // arcExclusive : -1=only non-archived; 0=don't care; 1=only archived
         $arcExclusive = $this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null, 'archive', 'sDEF');
-        $this->arcExclusive = $arcExclusive ? $arcExclusive : intval($this->conf['archive']);
+        $this->arcExclusive = $arcExclusive ? $arcExclusive : intval($this->conf['archive'] ?? 0);
 
         $this->config['datetimeDaysToArchive'] = intval($this->conf['datetimeDaysToArchive'] ?? 0);
         $this->config['datetimeHoursToArchive'] = intval($this->conf['datetimeHoursToArchive'] ?? 0);
@@ -2715,7 +2715,7 @@ class TtNews extends AbstractPlugin
                     $markerArray['###NEWS_IMAGE###'] = $this->local_cObj->wrap($theImgCode, $lConf['imageWrapIfAny'] ?? false);
                 } else {
                     $markerArray['###NEWS_IMAGE###'] = $this->local_cObj->stdWrap($markerArray['###NEWS_IMAGE###'],
-                        $lConf['image.']['noImage_stdWrap.']);
+                        $lConf['image.']['noImage_stdWrap.'] ?? null);
                 }
             }
         }

--- a/Classes/Plugin/TtNews.php
+++ b/Classes/Plugin/TtNews.php
@@ -870,7 +870,7 @@ class TtNews extends AbstractPlugin
         $selectConf = $this->getSelectConf($where, $noPeriod);
 
         // performing query to count all news (we need to know it for browsing):
-        if ($selectConf['leftjoin'] || ($this->theCode == 'RELATED' && $this->relNewsUid)) {
+        if ($selectConf['leftjoin'] ?? false || ($this->theCode == 'RELATED' && $this->relNewsUid)) {
             $selectConf['selectFields'] = 'COUNT(DISTINCT tt_news.uid) as c';
         } else {
             $selectConf['selectFields'] = 'COUNT(tt_news.uid) as c';
@@ -899,7 +899,7 @@ class TtNews extends AbstractPlugin
             $this->renderMarkers = $this->getMarkers($t['total']);
 
             // build query for display:
-            if ($selectConf['leftjoin'] || ($this->theCode == 'RELATED' && $this->relNewsUid)) {
+            if ($selectConf['leftjoin'] ?? false || ($this->theCode == 'RELATED' && $this->relNewsUid)) {
                 $selectConf['selectFields'] = 'DISTINCT tt_news.uid, tt_news.*';
             } else {
                 $selectConf['selectFields'] = 'tt_news.*';
@@ -1196,7 +1196,7 @@ class TtNews extends AbstractPlugin
             // gets the option splitted config for this record
             if ($this->conf['enableOptionSplit'] && !empty($this->splitLConf[$cc])) {
                 $lConf = $this->splitLConf[$cc];
-                $lConf['subheader_stdWrap.']['crop'] .= $cropSuffix;
+                $lConf['subheader_stdWrap.']['crop'] = ($lConf['subheader_stdWrap.']['crop'] ?? '') . $cropSuffix;
 
             }
 
@@ -4556,6 +4556,11 @@ class TtNews extends AbstractPlugin
 
         $piVarsArray['tt_news'] = $row['uid'];
 
+        // hotfix AbstractPlugin not php8.1 compatible
+        if (!isset($this->conf['parent.']['addParams'])) {
+            $this->conf['parent.']['addParams'] = '';
+        }
+        // end hotfix
         $linkWrap = explode($this->token,
             $this->pi_linkTP_keepPIvars($this->token, $piVarsArray, $this->allowCaching, $this->conf['dontUseBackPid'],
                 $singlePid));

--- a/Classes/Plugin/TtNews.php
+++ b/Classes/Plugin/TtNews.php
@@ -3484,17 +3484,20 @@ class TtNews extends AbstractPlugin
             $markerArray['###SITE_LANG###'] = '';
         }
 
-        $imgFile = GeneralUtility::getFileAbsFileName($this->cObj->stdWrap($lConf['xmlIcon'],
-            $lConf['xmlIcon.']));
+        if (isset($lConf['xmlIcon'])) {
+            $imgFile = GeneralUtility::getFileAbsFileName($this->cObj->stdWrap($lConf['xmlIcon'], $lConf['xmlIcon.']));
+        } else {
+            $imgFile = null;
+        }
         $imgSize = is_file($imgFile) ? getimagesize($imgFile) : '';
-        $markerArray['###IMG_W###'] = $imgSize[0];
-        $markerArray['###IMG_H###'] = $imgSize[1];
+        $markerArray['###IMG_W###'] = $imgSize[0] ?? null;
+        $markerArray['###IMG_H###'] = $imgSize[1] ?? null;
 
         $relImgFile = str_replace(Environment::getPublicPath() . '/', '', $imgFile);
         $markerArray['###IMG###'] = GeneralUtility::getIndpEnv('TYPO3_SITE_URL') . $relImgFile;
 
-        $markerArray['###NEWS_WEBMASTER###'] = $lConf['xmlWebMaster'];
-        $markerArray['###NEWS_MANAGINGEDITOR###'] = $lConf['xmlManagingEditor'];
+        $markerArray['###NEWS_WEBMASTER###'] = $lConf['xmlWebMaster'] ?? null;
+        $markerArray['###NEWS_MANAGINGEDITOR###'] = $lConf['xmlManagingEditor'] ?? null;
 
         $selectConf = Array();
         $selectConf['pidInList'] = $this->pid_list;
@@ -3516,19 +3519,19 @@ class TtNews extends AbstractPlugin
             $markerArray['###NEWS_LASTBUILD###'] = $this->helpers->getW3cDate($row['maxval']);
         }
 
-        if ($lConf['xmlWebMaster']) {
+        if ($lConf['xmlWebMaster'] ?? null) {
             $markerArray['###NEWS_WEBMASTER###'] = '<webMaster>' . $lConf['xmlWebMaster'] . '</webMaster>';
         } else {
             $markerArray['###NEWS_WEBMASTER###'] = '';
         }
 
-        if ($lConf['xmlManagingEditor']) {
+        if ($lConf['xmlManagingEditor'] ?? null) {
             $markerArray['###NEWS_MANAGINGEDITOR###'] = '<managingEditor>' . $lConf['xmlManagingEditor'] . '</managingEditor>';
         } else {
             $markerArray['###NEWS_MANAGINGEDITOR###'] = '';
         }
 
-        if ($lConf['xmlCopyright']) {
+        if ($lConf['xmlCopyright'] ?? null) {
             if ($lConf['xmlFormat'] == 'atom1') {
                 $markerArray['###NEWS_COPYRIGHT###'] = '<rights>' . $lConf['xmlCopyright'] . '</rights>';
             } else {
@@ -3539,14 +3542,14 @@ class TtNews extends AbstractPlugin
         }
 
         $charset = ($this->tsfe->metaCharset ? $this->tsfe->metaCharset : 'iso-8859-1');
-        if ($lConf['xmlDeclaration']) {
+        if ($lConf['xmlDeclaration'] ?? null) {
             $markerArray['###XML_DECLARATION###'] = trim($lConf['xmlDeclaration']);
         } else {
             $markerArray['###XML_DECLARATION###'] = '<?xml version="1.0" encoding="' . $charset . '"?>';
         }
 
         // promoting TYPO3 in atom feeds, supress the subversion
-        $version = explode('.', ($GLOBALS['TYPO3_VERSION'] ? $GLOBALS['TYPO3_VERSION'] : $GLOBALS['TYPO_VERSION']));
+        $version = explode('.', (\TYPO3\CMS\Core\Utility\VersionNumberUtility::getCurrentTypo3Version()));
         unset($version[2]);
         $markerArray['###TYPO3_VERSION###'] = implode('.', $version);
 
@@ -3942,7 +3945,7 @@ class TtNews extends AbstractPlugin
             'LIMIT' => ''
         );
 
-        if (($where = trim($conf['where']))) {
+        if (($where = trim($conf['where'] ?? ''))) {
             $query .= ' AND ' . $where;
         }
 
@@ -4219,11 +4222,11 @@ class TtNews extends AbstractPlugin
 
         $splitMark = md5(microtime(true));
         $globalMarkerArray = array();
-        list($globalMarkerArray['###GW1B###'], $globalMarkerArray['###GW1E###']) = explode($splitMark,
+        [$globalMarkerArray['###GW1B###'], $globalMarkerArray['###GW1E###']] = explode($splitMark,
             $this->cObj->stdWrap($splitMark, $this->conf['wrap1.'] ?? false));
-        list($globalMarkerArray['###GW2B###'], $globalMarkerArray['###GW2E###']) = explode($splitMark,
+        [$globalMarkerArray['###GW2B###'], $globalMarkerArray['###GW2E###']] = explode($splitMark,
             $this->cObj->stdWrap($splitMark, $this->conf['wrap2.'] ?? false));
-        list($globalMarkerArray['###GW3B###'], $globalMarkerArray['###GW3E###']) = explode($splitMark,
+        [$globalMarkerArray['###GW3B###'], $globalMarkerArray['###GW3E###']] = explode($splitMark,
             $this->cObj->stdWrap($splitMark, $this->conf['wrap3.'] ?? false));
         $globalMarkerArray['###GC1###'] = $this->cObj->stdWrap($this->conf['color1'] ?? '', $this->conf['color1.'] ?? false);
         $globalMarkerArray['###GC2###'] = $this->cObj->stdWrap($this->conf['color2'] ?? '', $this->conf['color2.'] ?? false);

--- a/Classes/Plugin/TtNews.php
+++ b/Classes/Plugin/TtNews.php
@@ -491,7 +491,7 @@ class TtNews extends AbstractPlugin
 
         // "CODE" decides what is rendered: codes can be set by TS or FF with priority on FF
         $code = $this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'what_to_display', 'sDEF');
-        $this->config['code'] = ($code ? $code : $this->cObj->stdWrap($this->conf['code'], $this->conf['code.']));
+        $this->config['code'] = ($code ? $code : $this->cObj->stdWrap($this->conf['code'], $this->conf['code.'] ?? []));
 
         if (($this->conf['displayCurrentRecord'] ?? false)) {
             $this->config['code'] = $this->conf['defaultCode'] ? trim($this->conf['defaultCode']) : 'SINGLE';
@@ -4246,7 +4246,7 @@ class TtNews extends AbstractPlugin
 
         $recursive = $this->pi_getFFvalue($this->cObj->data['pi_flexform'], 'recursive', 's_misc');
         if (!strcmp($recursive, '') || $recursive === null) {
-            $recursive = $this->cObj->stdWrap($this->conf['recursive'], $this->conf['recursive.']);
+            $recursive = $this->cObj->stdWrap($this->conf['recursive'], $this->conf['recursive.'] ?? []);
         }
 
         // extend the pid_list by recursive levels

--- a/Configuration/TCA/tt_news.php
+++ b/Configuration/TCA/tt_news.php
@@ -1,7 +1,7 @@
 <?php
 
 // get extension confArr
-$confArr = $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['tt_news'];
+$confArr = $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['tt_news'] ?? [];
 // switch the use of the "StoragePid"(general record Storage Page) for tt_news categories
 $fTableWhere = (($confArr['useStoragePid'] ?? false) ? 'AND tt_news_cat.pid=###STORAGE_PID### ' : '');
 // page where records will be stored in that have been created with a wizard


### PR DESCRIPTION
This is my current state of bugfixes that allows at least LIST/LATEST/SINGLE for a big legacy system.

It relies on TYPO3 v11.4.20, as AbstractPlugin is still not fully PHP8.1 compatible, see
- https://review.typo3.org/c/Packages/TYPO3.CMS/+/76598 (this can be hotfixed inside tt_news)
- https://review.typo3.org/c/Packages/TYPO3.CMS/+/76642
- https://review.typo3.org/c/Packages/TYPO3.CMS/+/76643

~I still got a small exception in my RSS feed, will add to this PR if that is resolved, but I think this here will already help a lot~ done