### PR TITLE
[REGRESSION] empty categories should be supported

### DIFF
--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -151,7 +151,7 @@ class DataHandlerHook
             $allowedItems = $this->getBeUser()->getTSConfig()['tt_newsPerms.']['tt_news_cat.']['allowedItems'] ?? '';
             $allowedItems = $allowedItems ? GeneralUtility::intExplode(',', $allowedItems) : Div::getAllowedTreeIDs();
 
-            $wantedCategories = GeneralUtility::intExplode(',', $fieldArray['category'] ?? '');
+            $wantedCategories = $fieldArray['category'] ? GeneralUtility::intExplode(',', $fieldArray['category']) : [];
             foreach ($wantedCategories as $wantedCategory) {
                 $categories[$wantedCategory] = $wantedCategory;
             }


### PR DESCRIPTION
During the big merge, somehow #195 was marked as merged, but the resulting code didn't include the change. Thus, the categories bug was reintroduced, which prevented e.g. (un)hiding records in list view.