### PR TITLE
[BUGFIX] Prevent undefined array key parent_category warning in DataHandlerHook

### DIFF
--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -78,7 +78,7 @@ class DataHandlerHook
     {
         if ($table == 'tt_news_cat' && is_int($id)) {
             // prevent moving of categories into their rootline
-            $newParent = (int)($fieldArray['parent_category']);
+            $newParent = (int)($fieldArray['parent_category'] ?? 0);
 
             if ($newParent && GeneralUtility::inList(
                 Div::getSubCategories(
@@ -306,7 +306,6 @@ class DataHandlerHook
      * @param             $srcId
      * @param             $destId
      * @param DataHandler $pObj
-     *
      */
     public function processCmdmap_postProcess($command, $table, $srcId, $destId, &$pObj): void
     {


### PR DESCRIPTION
resolves #209 